### PR TITLE
Support Python 3.x in addition to Python 2.x

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+from __future__ import nested_scopes
+from __future__ import generators
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import with_statement
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import io
 import sys
@@ -13,40 +20,40 @@ def answer_prompt(sio,prompt_to_wait_for,answer_to_write,send_cr=True):
   prompt_found = False
   data = ''
   #if send_cr:
-    #sio.write(unicode('\n'))
+    #sio.write('\n')
 
   d='something'
   while not len(d)==0:
     d = sio.read(2000);
     data += d
     time.sleep(1)
-#    print '-' * 50
-#    print ' %d bytes read' % (len(data))
-#    print '-' * 50
+#    print( '-' * 50)
+#    print(' %d bytes read' % (len(data)))
+#    print('-' * 50)
 
-  #print data
+#  print(data)
 
   line=''
   while not prompt_found:
     d = sio.read(100);
     data += d
-#    print '-' * 50
-#    print ' %d bytes read' % (len(data))
-#    print '-' * 50
-#    print data
-#    print '-' * 50
+#    print('-' * 50)
+#    print(' %d bytes read' % (len(data)))
+#    print('-' * 50)
+#    print(data)
+#    print('-' * 50)
     if len(data.split())>0:
       line=data.split()[-1]
-#    print "matching [%s] against [%s]" % (line,prompt_to_wait_for)
+#    print("matching [%s] against [%s]" % (line,prompt_to_wait_for))
     if(re.match(prompt_to_wait_for,line,re.M)):
-        sio.write(unicode(answer_to_write+'\n'))
-#        print '-' * 50
-#        print ' detected [%s] ' % prompt_to_wait_for
-#        print '-' * 50
+        sio.write(answer_to_write+'\n')
+#        print('-' * 50)
+#        print(' detected [%s] ' % prompt_to_wait_for)
+#        print('-' * 50)
         prompt_found = True
     else:
         if send_cr:
-          sio.write(unicode('\n'))
+          sio.write('\n')
     sio.flush()
     #sys.stdin.readline()
 
@@ -57,15 +64,15 @@ def scanfor(sio,regexp_to_scan_for,answer_to_write):
   data = ''
   while not prompt_found:
     data += sio.read(100);
-#    print '-' * 50
-#    print ' %d bytes read' % (len(data))
-#    print '-' * 50
-#    print data
+#    print('-' * 50)
+#    print(' %d bytes read' % (len(data)))
+#    print('-' * 50)
+#    print(data)
     if re.search(regexp_to_scan_for,data):
-#        print '-' * 50
-#        print ' detected [%s] ' % regexp_to_scan_for
-#        print '-' * 50
-        sio.write(unicode(answer_to_write+'\n'))
+#        print('-' * 50)
+#        print(' detected [%s] ' % regexp_to_scan_for)
+#        print('-' * 50)
+        sio.write(answer_to_write+'\n')
         prompt_found = True
     sio.flush()
   return data
@@ -80,34 +87,34 @@ def main():
   else:
     serial_port='/dev/ttyACM0';
 
-  #print 'reading from %s:' % serial_port
+  #print('reading from %s:' % serial_port)
 
   ser = serial.Serial(serial_port,115200, timeout=1);
   sio = io.TextIOWrapper(io.BufferedRWPair(ser,ser))
 
   #login
 
-  print "login...",
+  print("login...", end='')
   sys.stdout.flush()
   answer_prompt(sio,'.*login:','chip',True)
-  print "OK\npassword...",
+  print("OK\npassword...", end='')
   sys.stdout.flush()
   answer_prompt(sio,'.*Password:','chip',False)
-  print "OK\npoweroff...",
+  print("OK\npoweroff...", end='')
   sys.stdout.flush()
   answer_prompt(sio,'.*[\$#]','sudo poweroff')
   answer_prompt(sio,'.*:','chip')
   time.sleep(2)
-  print "OK\n",
+  print("OK")
   #d=scanfor(sio,r'.*### [^#]+ ###.*','poweroff')
 #  if re.search(r'.*### ALL TESTS PASSED ###.*',d):
-#    print "---> TESTS PASSED"
+#    print("---> TESTS PASSED")
 #    ser.close();
 #    return 0 
     
   ser.close();
   
-#  print "---> TESTS FAILED"
+#  print("---> TESTS FAILED")
   return 0
 
 


### PR DESCRIPTION
Tested on python 2.7.10 and python 3.5.0
Theoretically it should also support the range from python 2.1 to python 3.x

Also I haven't seen the documentation of the use of external libraries  (pyserial)
Therefor we should inform people to install python-pip (or python2-pip) packages, and that they then run `pip install pyserial` or `pip2 install pyserial`.

Signoff, Rikard Söderström soderstrom.rikard@gmail.com
