### PR TITLE
Fix the non-fastboot flashing early-quit scenario.

### DIFF
--- a/chip-fel-flash.sh
+++ b/chip-fel-flash.sh
@@ -131,7 +131,11 @@ prepare_uboot_script() {
     echo "echo " >>"${UBOOT_SCRIPT_SRC}"
     echo "echo *****************[ FLASHING DONE ]*****************" >>"${UBOOT_SCRIPT_SRC}"
     echo "echo " >>"${UBOOT_SCRIPT_SRC}"
-    echo "while true; do; sleep 10; done;" >>"${UBOOT_SCRIPT_SRC}"
+    if [[ "${METHOD}" == "fel" ]]; then
+      echo "reset"
+    else
+      echo "while true; do; sleep 10; done;" >>"${UBOOT_SCRIPT_SRC}"
+    fi
   fi
 
 	mkimage -A arm -T script -C none -n "flash CHIP" -d "${UBOOT_SCRIPT_SRC}" "${UBOOT_SCRIPT}"
@@ -204,4 +208,13 @@ else
 	fi
 fi
 
+if [[ "${METHOD}" == "fel" ]]; then
+	if ! wait_for_linuxboot; then
+		echo "ERROR: could not flash":
+		rm -rf $(TMPDIR)
+		exit 1
+	else
+		${SCRIPTDIR}/verify.sh
+	fi
+fi
 rm -rf "${TMPDIR}"

--- a/chip-update-firmware.sh
+++ b/chip-update-firmware.sh
@@ -149,11 +149,11 @@ cache_download "${FW_IMAGE_DIR}" ${BR_URL} u-boot-dtb.bin
 
 BUILDROOT_OUTPUT_DIR="${FW_DIR}" ${FLASH_SCRIPT} ${FLASH_SCRIPT_OPTION} || echo "ERROR: could not flash" && exit 1
 
-if ! wait_for_linuxboot; then
-  echo "ERROR: could not flash"
-  exit 1
-else
-  ${SCRIPTDIR}/verify.sh
-fi
+#if ! wait_for_linuxboot; then
+#  echo "ERROR: could not flash"
+#  exit 1
+#else
+#  ${SCRIPTDIR}/verify.sh
+#fi
 
 exit $?


### PR DESCRIPTION
Added reset to uboot.scr for fel flashes, triggers wait_for_linux properly now if METHOD=fel.