### PR TITLE
Fixed bug in chip-fel-flash.sh

### DIFF
--- a/chip-fel-flash.sh
+++ b/chip-fel-flash.sh
@@ -211,7 +211,7 @@ fi
 if [[ "${METHOD}" == "fel" ]]; then
 	if ! wait_for_linuxboot; then
 		echo "ERROR: could not flash":
-		rm -rf $(TMPDIR)
+		rm -rf ${TMPDIR}
 		exit 1
 	else
 		${SCRIPTDIR}/verify.sh


### PR DESCRIPTION
Where script was trying to run a variable name as a shell command rather than getting the value.